### PR TITLE
added rinkeby network and dotenv

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -18,5 +18,13 @@ task("accounts", "Prints the list of accounts", async () => {
  */
 module.exports = {
   solidity: "0.6.12",
+  networks: {
+    rinkeby: {
+      url: "https://rinkeby.infura.io/v3/"+process.env.PROJECT_ID,
+      accounts: {
+        mnemonic: process.env.MNEMONIC
+      }
+    }
+  }
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2038,6 +2038,11 @@
       "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==",
       "dev": true
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
     "drbg.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@openzeppelin/contracts": "^3.2.0",
+    "dotenv": "^8.2.0",
     "eccrypto": "^1.1.5"
   }
 }


### PR DESCRIPTION
hardhat config has been modified to accept rinkeby as a network on a contract deployment.
account data and infura project id is stored on a .env file, hence dotenv was added into package.json
